### PR TITLE
fix ParsingError when calling status() on tailscale 1.82.0

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -98,7 +98,10 @@ pub struct Status {
     pub backend_state: BackendState,
     #[serde(rename = "AuthURL")]
     pub auth_url: String,
-    #[serde(rename = "TailscaleIPs", deserialize_with = "deserialize_default_from_null")]
+    #[serde(
+        rename = "TailscaleIPs",
+        deserialize_with = "deserialize_default_from_null"
+    )]
     pub tailscale_ips: Vec<IpAddr>,
     #[serde(rename = "Self")]
     pub self_status: PeerStatus,
@@ -200,7 +203,7 @@ pub struct UserProfile {
     pub login_name: String,
     pub display_name: String,
     #[serde(rename = "ProfilePicURL")]
-    pub profile_pic_url: String,
+    pub profile_pic_url: Option<String>,
 }
 
 /// Whois response


### PR DESCRIPTION
> ParsingError(Error("missing field `ProfilePicURL`", line: 12396, column: 3))

profile_pic_url is optional/omittied with https://github.com/tailscale/tailscale/commit/5a082fccecbf8bedcdc8bd427bbd1f9068556dd3