### PR TITLE
Pass header 'Sec-Tailscale: localapi' to TCP localapi

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,6 +200,7 @@ impl LocalApiClient for TcpWithPasswordClient {
                         .encode(format!(":{}", self.password))
                 ),
             )
+            .header("Sec-Tailscale", "localapi")
             .uri(uri)
             .body(Body::empty())?;
 


### PR DESCRIPTION
Tailscale's loopback server API require clients to pass "Sec-Tailscale: localapi" unconditionally. See
https://pkg.go.dev/tailscale.com/tsnet#Server.Loopback.