### PR TITLE
Update Nullable Fields in Node Following Tailscale API Change 🌯

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -168,7 +168,7 @@ pub struct Node {
     pub sharer: Option<i64>,
     pub key: String,
     pub key_expiry: DateTime<Utc>,
-    pub machine: String,
+    pub machine: Option<String>,
     pub disco_key: String,
     pub addresses: Vec<String>,
     #[serde(rename = "AllowedIPs")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -167,9 +167,9 @@ pub struct Node {
     pub user: i64,
     pub sharer: Option<i64>,
     pub key: String,
-    pub key_expiry: DateTime<Utc>,
+    pub key_expiry: Option<DateTime<Utc>>,
     pub machine: Option<String>,
-    pub disco_key: String,
+    pub disco_key: Option<String>,
     pub addresses: Vec<String>,
     #[serde(rename = "AllowedIPs")]
     pub allowed_ips: Vec<String>,


### PR DESCRIPTION
For Tailscale versions >1.90, parsing the `Node` struct results in parsing errors like `missing field "Machine"`. 

See https://github.com/tailscale/tailscale/commit/5b0c57f497ffe1c83dc2e4c7026541264ecd0f8a#diff-f0a557b2e6146bf0086496e768823138d674067af50073befc070f786dff3653R353.